### PR TITLE
Integrate with BE and Photo Details Page

### DIFF
--- a/FlickrPhoto.xcodeproj/project.pbxproj
+++ b/FlickrPhoto.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -435,6 +436,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/FlickrPhoto/App/ContentView.swift
+++ b/FlickrPhoto/App/ContentView.swift
@@ -27,12 +27,9 @@ struct ContentView: View {
 			}
 			.navigationTitle("Flickr")
 			.onChange(of: searchText) { _, newValue in
-				viewModel.mockSearchTextUpdated(searchText: newValue)
+				viewModel.searchForPhotos(withSearchString: newValue)
 			}
 		} //: NavigationStack
-		.onAppear {
-			viewModel.mockSearchTextUpdated(searchText: "")
-		}
 		.padding(.horizontal)
 	}
 }

--- a/FlickrPhoto/Extensions/String+removeSpaces.swift
+++ b/FlickrPhoto/Extensions/String+removeSpaces.swift
@@ -1,0 +1,16 @@
+//
+//  String+removeSpaces.swift
+//  FlickrPhoto
+//
+//  Created by Stephen Brundage on 11/11/24.
+//
+
+import Foundation
+
+extension String {
+	func removeSpaces() -> String {
+		// Search tags will be formatted as: porcupine, lion, horse
+		// We can remove all spaces and send this into the API call
+		self.replacingOccurrences(of: " ", with: "")
+	}
+}

--- a/FlickrPhoto/Helpers/NetworkManager.swift
+++ b/FlickrPhoto/Helpers/NetworkManager.swift
@@ -1,0 +1,52 @@
+//
+//  NetworkManager.swift
+//  FlickrPhoto
+//
+//  Created by Stephen Brundage on 11/11/24.
+//
+
+import Foundation
+
+class NetworkManager {
+	private let flickrUrl = "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags="
+	private weak var dataTask: URLSessionTask?
+	
+	func fetchPhotosForSearch(searchText: String, completion: @escaping (Result<[FlickrResult], NetworkError>) -> Void) {
+		let noSpacesSearchText = searchText.removeSpaces()
+		let entireUrl = flickrUrl + noSpacesSearchText
+		
+		dataTask?.cancel()
+		
+		guard let request = createUrlRequest(forUrl: entireUrl) else {
+			completion(.failure(.invalidUrl))
+			return
+		}
+		
+		dataTask = URLSession.shared.dataTask(with: request, completionHandler: { data, response, error in
+			guard
+				let data = data,
+				error == nil
+			else {
+				completion(.failure(.networkResponseError(error!)))
+				return
+			}
+			
+			do {
+				let decodedResponse = try JSONDecoder().decode(SearchResultResponse.self, from: data)
+				let flickrResults: [FlickrResult] = decodedResponse.items?.compactMap { FlickrResult(searchResult: $0) } ?? []
+				completion(.success(flickrResults))
+			} catch {
+				completion(.failure(.decodingError))
+			}
+		})
+		
+		dataTask?.resume()
+	}
+	
+	private func createUrlRequest(forUrl urlString: String) -> URLRequest? {
+		guard let url = URL(string: urlString) else { return nil }
+		var request = URLRequest(url: url)
+		request.httpMethod = "GET"
+		return request
+	}
+}

--- a/FlickrPhoto/Models/NetworkError.swift
+++ b/FlickrPhoto/Models/NetworkError.swift
@@ -1,0 +1,15 @@
+//
+//  NetworkError.swift
+//  FlickrPhoto
+//
+//  Created by Stephen Brundage on 11/11/24.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+	case invalidUrl
+	case networkResponseError(Error)
+	case decodingError
+	case unknownError(Error)
+}

--- a/FlickrPhoto/ViewModels/FlickrViewModel.swift
+++ b/FlickrPhoto/ViewModels/FlickrViewModel.swift
@@ -10,6 +10,8 @@ import Foundation
 final class FlickrViewModel: ObservableObject {
 	
 	@Published var searchResults: [FlickrResult] = []
+	
+	private let networkManager = NetworkManager()
 		
 	func mockSearchTextUpdated(searchText: String) {
 		DispatchQueue.main.async {
@@ -32,6 +34,17 @@ final class FlickrViewModel: ObservableObject {
 	}
 	
 	func searchForPhotos(withSearchString searchString: String) {
-		
+		networkManager.fetchPhotosForSearch(searchText: searchString) { [weak self] result in
+			guard let self else { return }
+			switch result {
+			case .success(let photoResults):
+				DispatchQueue.main.async { [weak self] in
+					guard let self else { return }
+					searchResults = photoResults
+				}
+			case .failure(let error):
+				print("Error fetching photos: \(error)")
+			}
+		}
 	}
 }

--- a/FlickrPhoto/ViewModels/GalleryGridView.swift
+++ b/FlickrPhoto/ViewModels/GalleryGridView.swift
@@ -35,25 +35,19 @@ struct GalleryGridView: View {
 	// MARK: - Body
 	
 	var body: some View {
-		// TODO: Is this necessary?
 		ScrollView(.vertical, showsIndicators: false) {
 			
 			// MARK: - Dynamic Photo Grid
 			
 			LazyVGrid(columns: gridLayout, alignment: .center, spacing: 10) {
 				ForEach(photos) { photo in
-//					NavigationLink(destination: FlickrImageDetailView(flickrImage: photo)) {
-//						PhotoResultView(
-//							photoUrl: photo.media?.m,
-//							width: 150,
-//							height: 150
-//						)
-//					}
-					PhotoResultView(
-						photoUrl: photo.media?.m,
-						width: 150,
-						height: 150
-					)
+					NavigationLink(destination: FlickrImageDetailView(flickrImage: photo)) {
+						PhotoResultView(
+							photoUrl: photo.media?.m,
+							width: 150,
+							height: 150
+						)
+					}
 					
 				} //: ForEach
 			} //: LazyVGrid

--- a/FlickrPhoto/Views/FlickrImageDetailView.swift
+++ b/FlickrPhoto/Views/FlickrImageDetailView.swift
@@ -1,0 +1,73 @@
+//
+//  FlickrImageDetailView.swift
+//  FlickrPhoto
+//
+//  Created by Stephen Brundage on 11/11/24.
+//
+
+import SwiftUI
+
+struct FlickrImageDetailView: View {
+	
+	let flickrImage: FlickrResult
+	
+	var body: some View {
+		ScrollView(.vertical, showsIndicators: false) {
+			VStack(spacing: 0) {
+				PhotoResultView(
+					photoUrl: flickrImage.media?.m,
+					width: 300,
+					height: 300
+				)
+				
+				Text(flickrImage.title)
+					.font(.title)
+					.padding(.vertical, 24)
+				
+				VStack(alignment: .leading, spacing: 24) {
+					Text("Description")
+						.font(.headline)
+						.background(
+							Color.accentColor
+								.frame(height: 2)
+								.offset(y: 16)
+						)
+					
+					Text(flickrImage.description ?? "NA")
+						.foregroundStyle(Color.accentColor)
+					
+					Text("Author")
+						.font(.headline)
+						.background(
+							Color.accentColor
+								.frame(height: 2)
+								.offset(y: 16)
+						)
+						.padding(.top, 12)
+					
+					Text(flickrImage.author ?? "NA")
+						.foregroundStyle(Color.accentColor)
+					
+					Text("Published")
+						.font(.headline)
+						.background(
+							Color.accentColor
+								.frame(height: 2)
+								.offset(y: 16)
+						)
+						.padding(.top, 12)
+					
+					Text(flickrImage.publishedDate ?? "NA")
+						.foregroundStyle(Color.accentColor)
+				}
+				.frame(maxWidth: .infinity, alignment: .leading)
+				.padding(.vertical)
+			} //: VStack
+		} //: ScrollView
+		.padding(.horizontal)
+	}
+}
+
+#Preview {
+	FlickrImageDetailView(flickrImage: FlickrResult.mocked())
+}

--- a/FlickrPhotoTests/StringManipulationTests.swift
+++ b/FlickrPhotoTests/StringManipulationTests.swift
@@ -16,4 +16,12 @@ final class StringManipulationTests: XCTestCase {
 		let expectedNoSpacesSearchText = "porcupine,lion,horse,dog"
 		XCTAssertEqual(searchText.removeSpaces(), expectedNoSpacesSearchText, "Strings do not match.")
 	}
+	
+	func testConvertingDateString_WhenReceivedUnformattedStringFromServer_FormatSuccessfully() {
+		let unformattedDate = "2024-11-06T05:06:53Z"
+		let formattedDate = unformattedDate.formatDateString()
+		let expectedFormattedDate = "Wednesday, Nov 6, 2024"
+		
+		XCTAssertEqual(formattedDate, expectedFormattedDate, "Formatted date doesn't match expected format.")
+	}
 }

--- a/FlickrPhotoTests/StringManipulationTests.swift
+++ b/FlickrPhotoTests/StringManipulationTests.swift
@@ -1,0 +1,19 @@
+//
+//  StringManipulationTests.swift
+//  FlickrPhotoTests
+//
+//  Created by Stephen Brundage on 11/11/24.
+//
+
+@testable import FlickrPhoto
+
+import XCTest
+
+final class StringManipulationTests: XCTestCase {
+
+	func testWhenRemovingSpacesFromSearchText_AllSpacesRemovedAndTagsAreSeparatedByCommas() {
+		let searchText = "porcupine, lion, horse, dog"
+		let expectedNoSpacesSearchText = "porcupine,lion,horse,dog"
+		XCTAssertEqual(searchText.removeSpaces(), expectedNoSpacesSearchText, "Strings do not match.")
+	}
+}


### PR DESCRIPTION
## Summary
Update UI to fetch data from the Flickr API and create details page for each photo.

### Description
Create `NetworkManager` to handle fetching data from Flickr API.  It uses the search term from the search bar to make the call.  UI is updated with each response.

Photo Details page has been created.  User can tap on any photo to open a details page where it displays title, description, author and published date.

## Screenshots

UI updates with API response |
--------------------------- |
![Flickr](https://github.com/user-attachments/assets/d5e780e9-a4d6-4e33-8e83-45f71acfbe0a) |

Photo Details Page |
------------------- |
![Simulator Screenshot - iPhone 16 Pro - 2024-11-11 at 09 37 03](https://github.com/user-attachments/assets/6df9c69b-9aa4-47e3-b9a0-2e689bfe3fea) |

## Unit Tests
![Screenshot 2024-11-11 at 9 44 52 AM](https://github.com/user-attachments/assets/169aa0bf-6bf2-447a-ba30-fd16a2094b8d)

- [x] testWhenRemovingSpacesFromSearchText_AllSpacesRemovedAndTagsAreSeparatedByCommas()
- [x] testConvertingDateString_WhenReceivedUnformattedStringFromServer_FormatSuccessfully()