### PR TITLE
Fix Identifiable error & Implement Error Handling

### DIFF
--- a/FlickrPhoto/App/ContentView.swift
+++ b/FlickrPhoto/App/ContentView.swift
@@ -21,7 +21,21 @@ struct ContentView: View {
 				SearchBar(searchText: $searchText, gridColumn: $gridColumn)
 					.padding(.vertical, 12)
 				
-				GalleryGridView(gridColumn: $gridColumn, photos: $viewModel.searchResults)
+				switch viewModel.networkStatus {
+					case .loading:
+						VStack {
+							Spacer()
+							ProgressView()
+								.tint(.accent)
+						}
+					case .loaded:
+						GalleryGridView(gridColumn: $gridColumn, photos: $viewModel.searchResults)
+					case .error(let description):
+						VStack {
+							Spacer()
+							Text("Error during networking request: \(description)")
+						}
+				}
 				
 				Spacer()
 			}

--- a/FlickrPhoto/Helpers/NetworkManager.swift
+++ b/FlickrPhoto/Helpers/NetworkManager.swift
@@ -18,7 +18,7 @@ class NetworkManager {
 		dataTask?.cancel()
 		
 		guard let request = createUrlRequest(forUrl: entireUrl) else {
-			completion(.failure(.invalidUrl))
+			completion(.failure(.invalidUrl(entireUrl)))
 			return
 		}
 		
@@ -27,7 +27,8 @@ class NetworkManager {
 				let data = data,
 				error == nil
 			else {
-				completion(.failure(.networkResponseError(error!)))
+				let resp = response as? HTTPURLResponse
+				completion(.failure(.networkResponseError(error, resp?.statusCode)))
 				return
 			}
 			

--- a/FlickrPhoto/Models/FlickrResult.swift
+++ b/FlickrPhoto/Models/FlickrResult.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct FlickrResult: Identifiable {
 	let id: String
-	let title: String
+	let title: String?
 	let link: String?
 	let media: ResultMedia?
 	let dateTaken: String?
@@ -19,11 +19,11 @@ struct FlickrResult: Identifiable {
 	
 	init?(searchResult: SearchResult) {
 		guard
-			let title = searchResult.title
+			let link = searchResult.link
 		else { return nil }
 		
-		self.id = title
-		self.title = title
+		self.id = link
+		self.title = searchResult.title
 		self.link = searchResult.link
 		self.media = searchResult.media
 		self.dateTaken = searchResult.dateTaken

--- a/FlickrPhoto/Models/NetworkError.swift
+++ b/FlickrPhoto/Models/NetworkError.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum NetworkError: Error {
-	case invalidUrl
-	case networkResponseError(Error)
+	case invalidUrl(String)
+	case networkResponseError(Error?, Int?)
 	case decodingError
 	case unknownError(Error)
 }

--- a/FlickrPhoto/Models/NetworkStatus.swift
+++ b/FlickrPhoto/Models/NetworkStatus.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkStatus.swift
+//  FlickrPhoto
+//
+//  Created by Stephen Brundage on 11/11/24.
+//
+
+import Foundation
+
+enum NetworkStatus {
+	case loading
+	case loaded
+	case error(_ description: String)
+}

--- a/FlickrPhoto/ViewModels/FlickrViewModel.swift
+++ b/FlickrPhoto/ViewModels/FlickrViewModel.swift
@@ -35,6 +35,8 @@ final class FlickrViewModel: ObservableObject {
 	}
 	
 	func searchForPhotos(withSearchString searchString: String) {
+		networkStatus = .loading
+		
 		networkManager.fetchPhotosForSearch(searchText: searchString) { [weak self] result in
 			guard let self else { return }
 			

--- a/FlickrPhoto/ViewModels/FlickrViewModel.swift
+++ b/FlickrPhoto/ViewModels/FlickrViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 final class FlickrViewModel: ObservableObject {
 	
 	@Published var searchResults: [FlickrResult] = []
+	@Published var networkStatus: NetworkStatus = .loaded
 	
 	private let networkManager = NetworkManager()
 		
@@ -36,14 +37,36 @@ final class FlickrViewModel: ObservableObject {
 	func searchForPhotos(withSearchString searchString: String) {
 		networkManager.fetchPhotosForSearch(searchText: searchString) { [weak self] result in
 			guard let self else { return }
+			
 			switch result {
-			case .success(let photoResults):
-				DispatchQueue.main.async { [weak self] in
-					guard let self else { return }
-					searchResults = photoResults
-				}
-			case .failure(let error):
-				print("Error fetching photos: \(error)")
+				case .success(let photoResults):
+					DispatchQueue.main.async { [weak self] in
+						guard let self else { return }
+						searchResults = photoResults
+						networkStatus = .loaded
+					}
+				case .failure(let error):
+					DispatchQueue.main.async { [weak self] in
+						guard let self else { return }
+						switch error {
+							case .invalidUrl(let url):
+								networkStatus = .error("Invalid API URL: \(url)")
+							case .networkResponseError(let error, let statusCode):
+								// Ignore -999 error codes as we invalid outstanding request on text field edit
+								guard
+									let statusCode = statusCode,
+									statusCode != -999
+								else {
+									networkStatus = .loaded
+									return
+								}
+								networkStatus = .error(error?.localizedDescription ?? "NetworkError with no returned description.")
+							case .decodingError:
+								networkStatus = .error("Trouble decoding response JSON.")
+							case .unknownError(let error):
+								networkStatus = .error("Unknown NetworkError: \(error.localizedDescription)")
+						}
+					}
 			}
 		}
 	}

--- a/FlickrPhoto/Views/FlickrImageDetailView.swift
+++ b/FlickrPhoto/Views/FlickrImageDetailView.swift
@@ -20,7 +20,7 @@ struct FlickrImageDetailView: View {
 					height: 300
 				)
 				
-				Text(flickrImage.title)
+				Text(flickrImage.title ?? "NA")
 					.font(.title)
 					.padding(.vertical, 24)
 				


### PR DESCRIPTION
## Summary
Title is not always unique, we should use `link` instead to fix this error.

Add error handling for each of the api calls and ignore `-999` errors as we invalidate outstanding network requests every time user types in the search bar.

Display progress loader when fetching from API and show error message if API call fails.

## Screenshots
Show Progress Loader |
---------------------- |
![Loading](https://github.com/user-attachments/assets/47e33cc1-0e8f-4995-9eff-5296b2baf983) |
